### PR TITLE
Fix - Consider the predicates passed

### DIFF
--- a/src/com/pattern/specification/predicate/Specification.java
+++ b/src/com/pattern/specification/predicate/Specification.java
@@ -7,21 +7,21 @@ public class Specification<E> {
     private Predicate<E> rules;
 
     public Specification(){
-        rules = (r) -> 1 == 1;
+        rules = (r) -> true;
     }
 
     public Specification<E> and(Predicate<E> rule) {
-        rules.and(rule);
+        rules = rules.and(rule);
         return this;
     }
 
     public Specification<E> or(Predicate<E> rule) {
-        rules.or(rule);
+        rules = rules.or(rule);
         return this;
     }
 
     public Specification<E> not(Predicate<E> rule) {
-        rules.and(rule).negate();
+        rules = rules.and(rule).negate();
         return this;
     }
 


### PR DESCRIPTION
Necessary to assign a variable for the wrapper to work appropriately. Previously I only considered the condition in the constructor.